### PR TITLE
In PrnParsePJL.cs const _maxPJLCmdLen increased to 1024

### DIFF
--- a/PCLParaphernalia/PrnParsePJL.cs
+++ b/PCLParaphernalia/PrnParsePJL.cs
@@ -21,7 +21,7 @@ namespace PCLParaphernalia
         //--------------------------------------------------------------------//
 
         private const Int32 _lenPJLIntro   = 4;       // @PJL //
-        private const Int32 _maxPJLCmdLen  = 256;
+        private const Int32 _maxPJLCmdLen  = 1024;
         private const Int32 _maxPJLLineLen = 50;
 
         //--------------------------------------------------------------------//


### PR DESCRIPTION
Hi Michael. I have found a problem with the parsing of PJL header in pcl6 files when Name of file is too long. Plus Name of file in UTF-8. I add file that generate an parsing error
 
[638205340502050957.csv](https://github.com/michaelknigge/pclparaphernalia/files/11592278/638205340502050957.csv)

Just rename it to pcl or prn extension because github doesn't support this format

I push PR for fix this problem with parsing but not with UTF-8